### PR TITLE
tmbdYTTrailer.py: Encode entry[2] to bytes

### DIFF
--- a/src/tmbdYTTrailer.py
+++ b/src/tmbdYTTrailer.py
@@ -217,7 +217,7 @@ class TmbdYTTrailerList(Screen, tmbdYTTrailer):
 			if not entry[2]:
 				self.decodeThumbnail(entry[0])
 			else:
-				downloadPage(entry[2], os.path.join('/tmp/', str(entry[0]) + '.jpg'))\
+				downloadPage(entry[2].encode(), os.path.join('/tmp/', str(entry[0]) + '.jpg'))\
 					.addCallback(boundFunction(self.downloadFinished, entry[0]))\
 					.addErrback(boundFunction(self.downloadFailed, entry[0]))
 


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Plugins/Extensions/TMBD/tmbdYTTrailer.py", line 218, in createThumbnails
    downloadPage(entry[2], os.path.join('/tmp/', str(entry[0]) + '.jpg'))\
  File "/usr/lib/python3.10/site-packages/twisted/python/deprecate.py", line 298, in deprecatedFunction
    return function(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/twisted/web/client.py", line 829, in downloadPage
    return _makeGetterFactory(
  File "/usr/lib/python3.10/site-packages/twisted/web/client.py", line 760, in _makeGetterFactory
    uri = URI.fromBytes(_ensureValidURI(url.strip()))
  File "/usr/lib/python3.10/site-packages/twisted/web/_newclient.py", line 634, in _ensureValidURI
    if _VALID_URI.match(uri):
TypeError: cannot use a bytes pattern on a string-like object