### PR TITLE
tmbdYTTrailer.py: Port to python3-treq

### DIFF
--- a/src/tmbdYTTrailer.py
+++ b/src/tmbdYTTrailer.py
@@ -4,7 +4,7 @@ import os
 from json import load
 from urllib.parse import quote
 from urllib.request import urlopen
-from twisted.web.client import downloadPage
+from treq import get, collect
 
 from enigma import ePicLoad, eTimer, eServiceReference
 from Components.ActionMap import ActionMap, HelpableActionMap
@@ -217,9 +217,11 @@ class TmbdYTTrailerList(Screen, tmbdYTTrailer):
 			if not entry[2]:
 				self.decodeThumbnail(entry[0])
 			else:
-				downloadPage(entry[2].encode(), os.path.join('/tmp/', str(entry[0]) + '.jpg'))\
+				f = open(os.path.join('/tmp/', str(entry[0]) + '.jpg'), "wb")
+				get(entry[2]).addCallback(collect, f.write)\
 					.addCallback(boundFunction(self.downloadFinished, entry[0]))\
-					.addErrback(boundFunction(self.downloadFailed, entry[0]))
+					.addErrback(boundFunction(self.downloadFailed, entry[0]))\
+					.addBoth(lambda _: f.close())
 
 	def downloadFinished(self, entryId, result):
 		image = os.path.join('/tmp/', str(entryId) + '.jpg')


### PR DESCRIPTION
downloadPage() is marked as deprecated since
Twisted v16.7.0 and will be removed with version 22.1. Good time to port to treq now.